### PR TITLE
Add RcppParallel cxxflags to makevars

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,4 +1,5 @@
 PKG_CPPFLAGS=-DRCPP_USE_UNWIND_PROTECT -DRCPP_NO_RTTI -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H @PCRE2_BUNDLED@ -I. @INCLUDE_PATHS@
+PKG_CXXFLAGS = $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::CxxFlags()")
 PKG_LIBS=-lpthread -L. -lSFPCRE2 @ADD_LIBS@ $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::RcppParallelLibs()")
 
 LIBPCRE2 = PCRE2/pcre2_chartables.o \

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,5 @@
 PKG_CPPFLAGS = -DRCPP_USE_UNWIND_PROTECT -DRCPP_NO_RTTI -DPCRE2_CODE_UNIT_WIDTH=8 -DHAVE_CONFIG_H -DPCRE2_BUNDLED -I. -IPCRE2
-PKG_CXXFLAGS = -DRCPP_PARALLEL_USE_TBB=1
+PKG_CXXFLAGS = -DRCPP_PARALLEL_USE_TBB=1 $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::CxxFlags()")
 PKG_LIBS     = -lpthread -L. -lSFPCRE2 $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::RcppParallelLibs()")
 
 LIBPCRE2 = PCRE2/pcre2_chartables.o \


### PR DESCRIPTION
Adds RcppParallel's `CXXFLAGS` to your package makevars, which are needed for compatibility with Windows ARM64